### PR TITLE
Fix Mosquitto TLS cert permissions

### DIFF
--- a/ansible/roles/mosquitto/files/mosquitto-cert-sync.service
+++ b/ansible/roles/mosquitto/files/mosquitto-cert-sync.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Synchronize Mosquitto TLS certificates from nginx-proxy cert store
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/sync-mosquitto-certs

--- a/ansible/roles/mosquitto/tasks/main.yml
+++ b/ansible/roles/mosquitto/tasks/main.yml
@@ -3,11 +3,74 @@
     src: mqtt
     dest: /srv/nginx-proxy/vhost.d/mqtt.hal9k.dk
 
+- name: Create Mosquitto directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner | default(omit) }}"
+    group: "{{ item.group | default(omit) }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - path: /srv/mosquitto
+      mode: '0755'
+    - path: /srv/mosquitto/config
+      mode: '0755'
+    - path: /srv/mosquitto/db
+      mode: '0755'
+    - path: /srv/mosquitto/certs
+      owner: '1883'
+      group: '1883'
+      mode: '0750'
+
 - name: Mosquitto configuration
   ansible.builtin.copy:
     src: config/
     dest: /srv/mosquitto/config/
   register: mosquitto_conf
+
+- name: Tighten Mosquitto ACL file permissions
+  ansible.builtin.file:
+    path: "{{ item }}"
+    mode: '0700'
+  loop:
+    - /srv/mosquitto/config/acl_file
+    - /srv/mosquitto/config/acl_file_secure
+
+- name: Install Mosquitto certificate sync script
+  ansible.builtin.template:
+    src: sync-mosquitto-certs.j2
+    dest: /usr/local/sbin/sync-mosquitto-certs
+    owner: root
+    group: root
+    mode: '0700'
+
+- name: Install Mosquitto certificate sync service
+  ansible.builtin.copy:
+    src: mosquitto-cert-sync.service
+    dest: /etc/systemd/system/mosquitto-cert-sync.service
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Install Mosquitto certificate sync path unit
+  ansible.builtin.template:
+    src: mosquitto-cert-sync.path.j2
+    dest: /etc/systemd/system/mosquitto-cert-sync.path
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Enable Mosquitto certificate sync watcher
+  ansible.builtin.systemd:
+    daemon_reload: yes
+    name: mosquitto-cert-sync.path
+    enabled: 'yes'
+    state: started
+
+- name: Run initial Mosquitto certificate sync
+  ansible.builtin.command: /usr/local/sbin/sync-mosquitto-certs
+  register: mosquitto_cert_sync
+  changed_when: "'changed' in mosquitto_cert_sync.stdout"
 
 - name: Mosquitto
   community.general.docker_container:
@@ -24,7 +87,7 @@
     volumes:
       - "/srv/mosquitto/config:/mosquitto/config"
       - "/srv/mosquitto/db:/mosquitto/db"
-      - "/srv/nginx-proxy/certs/mqtt.hal9k.dk:/mosquitto/certs"
+      - "/srv/mosquitto/certs:/mosquitto/certs:ro"
     env:
       VIRTUAL_HOST: "{{ mosquitto.hostname }}"
       LETSENCRYPT_HOST: "{{ mosquitto.hostname }}"

--- a/ansible/roles/mosquitto/templates/mosquitto-cert-sync.path.j2
+++ b/ansible/roles/mosquitto/templates/mosquitto-cert-sync.path.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Watch nginx-proxy certificate files for Mosquitto
+
+[Path]
+PathChanged=/srv/nginx-proxy/certs/{{ mosquitto.hostname }}/fullchain.pem
+PathChanged=/srv/nginx-proxy/certs/{{ mosquitto.hostname }}/key.pem
+Unit=mosquitto-cert-sync.service
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/mosquitto/templates/sync-mosquitto-certs.j2
+++ b/ansible/roles/mosquitto/templates/sync-mosquitto-certs.j2
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+
+SRC_DIR="/srv/nginx-proxy/certs/{{ mosquitto.hostname }}"
+DST_DIR="/srv/mosquitto/certs"
+TMP_FULLCHAIN="$DST_DIR/fullchain.pem.tmp"
+TMP_KEY="$DST_DIR/key.pem.tmp"
+TARGET_FULLCHAIN="$DST_DIR/fullchain.pem"
+TARGET_KEY="$DST_DIR/key.pem"
+CHANGED=0
+
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+[ -s "$SRC_DIR/fullchain.pem" ] || fail "Missing source certificate: $SRC_DIR/fullchain.pem"
+[ -s "$SRC_DIR/key.pem" ] || fail "Missing source key: $SRC_DIR/key.pem"
+
+install -d -o 1883 -g 1883 -m 0750 "$DST_DIR"
+install -o 1883 -g 1883 -m 0640 "$SRC_DIR/fullchain.pem" "$TMP_FULLCHAIN"
+install -o 1883 -g 1883 -m 0640 "$SRC_DIR/key.pem" "$TMP_KEY"
+
+if [ ! -f "$TARGET_FULLCHAIN" ] || ! cmp -s "$TMP_FULLCHAIN" "$TARGET_FULLCHAIN"; then
+  mv "$TMP_FULLCHAIN" "$TARGET_FULLCHAIN"
+  CHANGED=1
+else
+  rm -f "$TMP_FULLCHAIN"
+fi
+
+if [ ! -f "$TARGET_KEY" ] || ! cmp -s "$TMP_KEY" "$TARGET_KEY"; then
+  mv "$TMP_KEY" "$TARGET_KEY"
+  CHANGED=1
+else
+  rm -f "$TMP_KEY"
+fi
+
+if [ "$CHANGED" -eq 1 ] && docker inspect mosquitto >/dev/null 2>&1; then
+  docker restart mosquitto
+fi
+
+if [ "$CHANGED" -eq 1 ]; then
+  echo changed
+else
+  echo unchanged
+fi


### PR DESCRIPTION
## Summary
- deploy Mosquitto TLS certs into a dedicated host directory with uid/gid 1883 ownership
- install a sync script and systemd path watcher to propagate renewed certs automatically
- mount the deployed cert directory read-only into the Mosquitto container
- tighten Mosquitto ACL file permissions to remove startup warnings

## Validation
- parsed `ansible/roles/mosquitto/tasks/main.yml` as YAML
- `ansible-playbook --syntax-check ansible/.tmp-verify-mosquitto.yml`

## Notes
This avoids mounting the nginx-proxy ACME cert directory directly into Mosquitto, which could not read the root-only private key.